### PR TITLE
Enforce max participants on activity signup

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -32,6 +32,11 @@ A super simple FastAPI application that allows students to view and sign up for 
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
 
+### Manual verification
+
+- Try signing up the same student twice; the API should return `400` with `"Student is already signed up"`.
+- Fill an activity to its `max_participants` and attempt another signup; expect `400` with `"Activity is full"`.
+
 ## Data Model
 
 The application uses a simple data model with meaningful identifiers:

--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Enforce capacity limits before adding a new participant
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
## Summary
- block signups when an activity has reached its `max_participants`
- keep error messaging consistent via HTTP 400 responses
- document manual verification steps for duplicate signups and full activities

## Testing
- manual: attempt duplicate signup -> 400
- manual: fill activity to capacity then sign up one more -> 400